### PR TITLE
init: npu-infer template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI (smoke)
+on: [push, pull_request]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUNBUFFERED: "1"
+      ALLOW_FAKE_GEN: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+      - name: Launch API
+        run: |
+          python -m uvicorn src.api.server:app --host 127.0.0.1 --port 9100 &
+          echo $! > .uv.pid
+          sleep 4
+      - name: Health
+        run: curl -sSf http://127.0.0.1:9100/health
+      - name: Infer
+        run: |
+          curl -sSf -H "Content-Type: application/json" \
+            --data '{"prompt":"ping","max_new_tokens":8}' \
+            http://127.0.0.1:9100/v1/infer | tee out.json
+      - name: Stop
+        if: always()
+        run: kill $(cat .uv.pid) || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.venv/
+__pycache__/
+*.pyc
+.uv.pid
+.ov_cache/
+exports/
+models/
+checkpoints/
+*.zip

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# Blueprint_npu
-Blueprint_npu
+# NPU Inference Template (OpenVINO)
+Profile로 설정 → 모델 다운로드/Export(선택) → FastAPI 서버 → /health, /v1/infer.
+- 로컬(NPU): `scripts/run.ps1`
+- 모델 세팅: `scripts/setup_model.py --profile profiles/example-llm.yaml`
+- OV Export(선택): `python -m src.export.export_ov --ckpt checkpoints/epoch1 --out exports/gpt_ov`
+- 환경변수:
+  - OV_XML_PATH: OpenVINO IR xml 경로
+  - OV_DEVICE: NPU|AUTO|CPU
+  - ALLOW_FAKE_GEN=1 → 모델 없을 때 스모크용 가짜 응답
+- Swagger: http://127.0.0.1:9100/docs

--- a/profiles/example-llm.yaml
+++ b/profiles/example-llm.yaml
@@ -1,0 +1,6 @@
+task: "text-generation"
+device: "AUTO"         # NPU|AUTO|CPU
+weight_format: "fp16"  # fp16/int4 등
+hf_repo: "OpenVINO/Phi-4-mini-instruct-int4-ov"
+local_dir: "models/phi4mini_ov"
+xml_hint: "openvino_model.xml"   # 폴더 내 힌트 파일명

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.111.0
+uvicorn==0.30.0
+pydantic==2.7.0
+openvino==2025.1.0
+openvino-genai==2025.1.0.0
+huggingface_hub==0.25.2
+requests==2.32.3
+orjson==3.11.2
+ujson==5.10.0
+pyyaml==6.0.2

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference="Stop"
+if (!(Get-Command python -ErrorAction SilentlyContinue)) { throw "Python 필요" }
+python -m venv .venv
+\.\.venv\Scripts\Activate.ps1
+python -m pip install -U pip
+pip install -r requirements.txt
+if (-not $env:OV_DEVICE) { $env:OV_DEVICE="AUTO" }
+if (-not $env:OV_CACHE_DIR) { $env:OV_CACHE_DIR=".ov_cache" }
+python -m uvicorn src.api.server:app --host 127.0.0.1 --port 9100

--- a/scripts/setup_model.py
+++ b/scripts/setup_model.py
@@ -1,0 +1,23 @@
+import argparse, os, glob
+from huggingface_hub import snapshot_download
+
+
+def main(p):
+    import yaml
+
+    cfg = yaml.safe_load(open(p, "r", encoding="utf-8"))
+    os.makedirs(cfg["local_dir"], exist_ok=True)
+    snapshot_download(repo_id=cfg["hf_repo"], local_dir=cfg["local_dir"])
+    # 찾아서 OV_XML_PATH 힌트 출력
+    cands = glob.glob(
+        os.path.join(cfg["local_dir"], "**", cfg.get("xml_hint", "*.xml")),
+        recursive=True,
+    )
+    print("OV_XML_PATH=", cands[0] if cands else "(not found)")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", required=True)
+    a = ap.parse_args()
+    main(a.profile)

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import base64
+import os
+import time
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from src.infer.ov_model import OVRunner
+
+app = FastAPI(title="npu-infer-template", version="0.1.0")
+_runner = OVRunner()
+
+
+class InferReq(BaseModel):
+    prompt: str = Field("Hello NPU", min_length=1, max_length=2048)
+    max_new_tokens: int = 64
+
+
+@app.get("/health")
+def health():
+    return _runner.health()
+
+
+@app.post("/v1/infer")
+def infer(req: InferReq):
+    t0 = time.time()
+    out = _runner.generate(req.prompt, req.max_new_tokens)
+    return {"result": out, "elapsed_ms": int((time.time() - t0) * 1000)}

--- a/src/export/export_ov.py
+++ b/src/export/export_ov.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+
+
+def _run(cmd):
+    print("Running:", " ".join(cmd), flush=True)
+    p = subprocess.run(cmd, text=True, capture_output=True)
+    print(p.stdout)
+    print(p.stderr)
+    if p.returncode != 0:
+        raise SystemExit(p.returncode)
+
+
+def _find(out):
+    xs = glob.glob(os.path.join(out, "*.xml")) or glob.glob(
+        os.path.join(out, "**", "*.xml"), recursive=True
+    )
+    return xs[0] if xs else None
+
+
+def main(ckpt: str, out: str):
+    os.makedirs(out, exist_ok=True)
+    cmd = [
+        sys.executable,
+        "-m",
+        "optimum.exporters.openvino",
+        "--model",
+        ckpt,
+        "--task",
+        "text-generation-with-past",
+        "--weight-format",
+        "fp16",
+        "--ov_config",
+        "PERFORMANCE_HINT=LATENCY",
+        "--output",
+        out,
+    ]
+    try:
+        _run(cmd)
+        xml = _find(out)
+        if not xml:
+            cmd[cmd.index("text-generation-with-past")] = "text-generation"
+            _run(cmd)
+            xml = _find(out)
+        if not xml:
+            raise RuntimeError("No XML produced")
+        print("OK:", xml)
+    except SystemExit as e:
+        raise e
+    except Exception as e:
+        print("Export failed:", e)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+    main(a.ckpt, a.out)

--- a/src/infer/ov_model.py
+++ b/src/infer/ov_model.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import glob
+import os
+
+
+class OVRunner:
+    def __init__(self):
+        self.xml = os.environ.get("OV_XML_PATH") or self._auto_find()
+        self.device = os.environ.get("OV_DEVICE", "AUTO")
+        self.fake = os.environ.get("ALLOW_FAKE_GEN") == "1" or not os.path.exists(self.xml)
+        if not self.fake:
+            import openvino as ov
+
+            self.core = ov.Core()
+            self.compiled = self.core.compile_model(self.core.read_model(self.xml), self.device)
+
+    def _auto_find(self) -> str:
+        c1 = glob.glob("exports/**/*.xml", recursive=True)
+        c2 = glob.glob("models/**/*.xml", recursive=True)
+        return (c1 + c2 + ["exports/gpt_ov/openvino_model.xml"])[0]
+
+    def health(self):
+        try:
+            import openvino as ov
+
+            devs = ov.Core().available_devices
+            return {"status": "ok", "devices": devs, "model": ("fake" if self.fake else self.xml)}
+        except Exception as e:
+            return {"status": "degraded", "error": str(e), "model": ("fake" if self.fake else self.xml)}
+
+    def generate(self, prompt: str, max_new_tokens: int = 64) -> str:
+        if self.fake:
+            return f"[FAKE:{self.device}] {prompt} ... ({max_new_tokens})"
+        # 여기에 모델별 전처리/후처리 붙이면 됨. 템플릿은 에코형으로 둠.
+        # 예: tokenizer(prompt) → infer → detokenize
+        return f"[OV:{self.device}] {prompt} ... ({max_new_tokens})"


### PR DESCRIPTION
## Summary
- add FastAPI-based inference server template with OpenVINO runner and fake fallback
- include scripts for model setup, OpenVINO export, and local execution
- configure dependencies, profiles, gitignore, and CI smoke workflow

## Testing
- python -m compileall src scripts/setup_model.py

------
https://chatgpt.com/codex/tasks/task_e_68cbec99d174832c911dbdbbbc9383fe